### PR TITLE
Odgi stats consensus graphs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['20.07.1', '']
+        nxf_ver: ['20.10.0', '']
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@
 ----------------------------------------------------------------------------------------
 */
 
-nextflow.enable.dsl = 2
+nextflow.preview.dsl = 2
 
 params.input="${baseDir}/**.fa.gz"
 params.map_pct_id=90//false

--- a/main.nf
+++ b/main.nf
@@ -26,7 +26,7 @@ params.max_poa_length=10000
 params.do_viz=false
 params.do_layout=false
 params.do_stats=false
-params.consensus_jump_max="10"
+params.consensus_jump_max="10,100,1000,10000"
 
 def makeBaseName = { f -> """\
 ${f.getSimpleName()}.pggb-\
@@ -199,12 +199,15 @@ workflow {
     edyeet(fasta)
     seqwish(edyeet.out)
     smoothxg(seqwish.out)
-    odgiBuild(seqwish.out.collect{it[1]}.mix(smoothxg.out.gfa_smooth, smoothxg.out.consensus_smooth))
-    if (params.do_stats) {
-      odgiStats(odgiBuild.out)    
+    if (params.do_stats) { 
+      odgiBuild(seqwish.out.collect{it[1]}.mix(smoothxg.out.gfa_smooth, smoothxg.out.consensus_smooth.flatten())) 
+      odgiStats(odgiBuild.out)  
     }
-    odgiViz(odgiBuild.out)
-    odgiChop(odgiBuild.out)
+    else {
+      odgiBuild(smoothxg.out.gfa_smooth)
+    }
+    odgiViz(odgiBuild.out.filter(~".*smooth.*"))
+    odgiChop(odgiBuild.out.filter(~".*smooth.*"))
     odgiLayout(odgiChop.out)
     odgiDraw(odgiLayout.out)
 }

--- a/main.nf
+++ b/main.nf
@@ -9,7 +9,7 @@
 ----------------------------------------------------------------------------------------
 */
 
-nextflow.preview.dsl = 2
+nextflow.enable.dsl = 2
 
 params.input="${baseDir}/**.fa.gz"
 params.map_pct_id=90//false
@@ -25,6 +25,7 @@ params.max_edge_jump=5000
 params.max_poa_length=10000
 params.do_viz=false
 params.do_layout=false
+params.do_stats=false
 
 def makeBaseName = { f -> """\
 ${f.getSimpleName()}.pggb-\
@@ -40,14 +41,14 @@ W${params.min_subpath}-\
 e${params.max_edge_jump}\
 """ }
 
-fasta = Channel.fromPath("${params.input}").map { f -> tuple(makeBaseName(f), f) }
+fasta = channel.fromPath("${params.input}").map { f -> tuple(makeBaseName(f), f) }
 
 process edyeet {
   input:
-  tuple val(f), file(fasta)
+  tuple val(f), path(fasta)
 
   output:
-  tuple val(f), file(fasta), file("${f}.paf")
+  tuple val(f), path(fasta), path("${f}.paf")
 
   """
   edyeet -X \
@@ -65,10 +66,10 @@ process edyeet {
 
 process seqwish {
   input:
-  tuple val(f), file(fasta), file(alignment)
+  tuple val(f), path(fasta), path(alignment)
 
   output:
-  tuple val(f), file("${f}.seqwish.gfa")
+  tuple val(f), path("${f}.seqwish.gfa")
 
   """
   seqwish \
@@ -82,93 +83,110 @@ process seqwish {
 
 process smoothxg {
   input:
-  tuple val(f), file(graph)
+    tuple val(f), path(graph)
 
   output:
-  tuple val(f), file("${f}.smooth.gfa")
+    // val(f), emit: failure
+    path("${f}.smooth.gfa"), emit: gfa_smooth // TODO, file("${f}*.consensus*.gfa")
 
-  """
-  smoothxg \
-    -t ${task.cpus} \
-    -g $graph \
-    -w ${params.max_block_weight} \
-    -j ${params.max_path_jump} \
-    -e ${params.max_edge_jump} \
-    -l ${params.max_poa_length} \
-    -o ${f}.smooth.gfa \
-    -m ${f}.smooth.maf \
-    -s ${f}.consensus \
-    -a \
-    -C 5000 \
-  """
+  script:
+    """
+    smoothxg \
+      -t ${task.cpus} \
+      -g $graph \
+      -w ${params.max_block_weight} \
+      -j ${params.max_path_jump} \
+      -e ${params.max_edge_jump} \
+      -l ${params.max_poa_length} \
+      -o ${f}.smooth.gfa \
+      -m ${f}.smooth.maf \
+      -s ${f}.consensus \
+      -a \
+      -C 5000
+    """  
 }
 
 process odgiBuild {
   input:
-  tuple val(f), file(graph)
+  // tuple val(f), file(graph), file(consensus_graphs)
+  path(graph)
 
   output:
-  tuple val(f), file("${f}.smooth.og")
+  path("${graph}.og")
 
   """
-  odgi build -g $graph -o ${f}.smooth.og
+  odgi build -g $graph -o ${graph}.og
+  """
+}
+
+process odgiStats {
+  publishDir "${params.outdir}/odgiStats", mode: 'copy'
+
+  input: 
+  path(graph)
+
+  output:
+  path("${graph}.stats")
+
+  """
+  odgi stats -i $graph -S -s -d -l > "${graph}.stats"
   """
 }
 
 process odgiViz {
   input:
-  tuple val(f), file(graph)
+  path(graph)
 
   output:
-  tuple val(f), file("${f}.smooth.og.viz.png")
+  path("${graph}.viz.png")
 
   """
   odgi viz \
     -i $graph \
-    -o ${f}.smooth.og.viz.png \
+    -o ${graph}.viz.png \
     -x 1500 -y 500 -P 5
   """
 }
 
 process odgiChop {
   input:
-  tuple val(f), file(graph)
+  path(graph)
 
   output:
-  tuple val(f), file("${f}.smooth.chop.og")
+  path("${graph}.chop.og")
 
   """
-  odgi chop -i $graph -c 100 -o ${f}.smooth.chop.og
+  odgi chop -i $graph -c 100 -o ${graph}.chop.og
   """
 }
 
 process odgiLayout {
   input:
-  tuple val(f), file(graph)
+  path(graph)
 
   output:
-  tuple val(f), file(graph), file("${f}.smooth.chop.og.lay")
+  tuple path(graph), path("${graph}.lay")
 
   """
   odgi layout \
     -i $graph \
-    -o ${f}.smooth.chop.og.lay \
+    -o ${graph}.lay \
     -t ${task.cpus} -P
   """
 }
 
 process odgiDraw {
   input:
-  tuple val(f), file(graph), file(layoutGraph)
+  tuple path(graph), path(layoutGraph)
 
   output:
-  tuple val(f), file("${f}.smooth.chop.og.lay.png")
+  path("${layoutGraph}.png")
 
   """
   odgi draw \
     -i $graph \
     -c $layoutGraph \
-    -p ${f}.smooth.chop.og.lay.png \
+    -p ${layoutGraph}.png \
     -H 1000 -t ${task.cpus}
   """
 }
@@ -177,7 +195,8 @@ workflow {
     edyeet(fasta)
     seqwish(edyeet.out)
     smoothxg(seqwish.out)
-    odgiBuild(smoothxg.out)
+    odgiBuild(smoothxg.out.gfa_smooth)
+    odgiStats(odgiBuild.out)
     odgiViz(odgiBuild.out)
     odgiChop(odgiBuild.out)
     odgiLayout(odgiChop.out)


### PR DESCRIPTION
<!--
# nf-core/pangenome pull request

Many thanks for contributing to nf-core/pangenome!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/pangenome/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/pangenome branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/pangenome)

This will take care of #10. 
This PR only affects `main.nf`.

- I replaced all occurrences of `file` with `path` to stick to the DSL2 standard as specified at https://www.nextflow.io/docs/latest/dsl2.html#dsl2-migration-notes.
- 2 new parameters:
  - `do_stats=false`. If set to true, `odgi stats` will be executed for the `seqwish`, the `smoothxg`, and the `consensus` graphs.
  - `consensus_jump_max`. This specifies the maximum jump in nucleotides of a structural variant to include in the consensus graph. The argument is comma-separated. For each entry, a consensus graph will be generated and statistics will be produced, if `do_stats=true`.
- For better debugging, all `odgiStats` output is copied into the results folder under `results/odgiStats`. Later in the development, the output of this channel will be forwarded to `MultiQC`.

I was experimenting with `emit` in order to bend Nextflow to my need. However, I am still lacking some experience working with Nextflow. So I suspect that my code does, what I intend it to do. But there might be a neater way in Nextflow to get there. Or I don't stick to some formatting standards. Happy to learn!