### PR TITLE
fix pggb docker image to 20201125163549e465b0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pangenome/pggb:latest
+FROM ghcr.io/pangenome/pggb:20201125163549e465b0
 LABEL authors="Simon Heumos, Michael Heuer, Lukas Heumos, Erik Garrison, Andrea Guarracino" \
       description="Docker image containing all software requirements for the nf-core/pangenome pipeline"
 


### PR DESCRIPTION
<!--
# nf-core/pangenome pull request

Many thanks for contributing to nf-core/pangenome!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/pangenome/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/pangenome branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/pangenome)

This PR intends to fix #18.
This PR only affects `Dockerfile`.

For better debugging purposes, we fix the `pggb` docker image version imported in `Dockerfile`.